### PR TITLE
ci: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+  workflow_dispatch:
+  schedule:
+    - cron: "46 11 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Rust and JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust, javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What
- Add a CodeQL workflow for Rust and JavaScript/TypeScript.
- Run on pull requests, pushes, scheduled scans, and manual dispatch.

## Why
- GitHub code scanning is not configured on the default branch, so code-level findings are not being surfaced.

## How
- Use CodeQL advanced setup with no-build analysis for Rust and JavaScript/TypeScript.

## Testing
- Commands run: GitHub PR checks pending.
- Results: Pending.

## Performance impact
- Bundle delta: N/A
- Build time delta: N/A
- Lighthouse delta: N/A
- API latency delta: N/A
- DB query delta: N/A

## Risk / Notes
- Config-only CodeQL setup.

## Screenshots (UI only)
- N/A

## Lockfile rationale (if lockfile changed)
- N/A

## Baseline governance (if .perf-baselines changed)
- `perf-baseline-update` label applied: N/A
- Reviewer signoff: N/A
- Rollback note: remove `.github/workflows/codeql.yml` if it causes runner issues.